### PR TITLE
Redis-Brain loaded event

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ For example, `export REDIS_URL=redis://passwd@192.168.0.1:16379/prefix` would
 authenticate with `password`, connecting to 192.168.0.1 on port 16379, and store
 data using the `prefix:storage` key.
 
+## Events
+
+Once redis is connected it will emit an event `"redis-brain-connected"` that all
+the other scripts will be able to access. When this event is triggered, it means
+that redis has been successfully connected and the data is available for all other scripts.
+
+To listen on this event:
+
+```
+    robot.on "redis-brain-connected", () ->
+```
+
+and write any other functionality that would be necessary once the redis brain
+has been connected.
+
+
 ### Installing your own
 
 If you need to install and

--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -47,9 +47,11 @@ module.exports = (robot) ->
       else if reply
         robot.logger.info "hubot-redis-brain: Data for #{prefix} brain retrieved from Redis"
         robot.brain.mergeData JSON.parse(reply.toString())
+        robot.emit "redis-brain-connected"
       else
         robot.logger.info "hubot-redis-brain: Initializing new data for #{prefix} brain"
         robot.brain.mergeData {}
+        robot.emit "redis-brain-connected"
 
       robot.brain.setAutoSave true
 


### PR DESCRIPTION
Adding event where the Redis-brain once it is loaded with data will trigger and allow other scripts to listen on that event and do other necessary actions.
